### PR TITLE
Fix get_error method

### DIFF
--- a/lib/phoenix_bootstrap_form.ex
+++ b/lib/phoenix_bootstrap_form.ex
@@ -110,8 +110,8 @@ defmodule PhoenixBootstrapForm do
       true ->
         msg   = form.errors[field] |> elem(0)
         opts  = form.errors[field] |> elem(1)
-        Enum.reduce(opts, msg, fn({key, value}, _acc) ->
-         String.replace(msg, "%{#{key}}", to_string(value))
+        Enum.reduce(opts, msg, fn {key, value}, acc ->
+          acc = String.replace(acc, "%{#{key}}", to_string(value))
         end)
       _ -> nil
     end

--- a/test/phoenix_bootstrap_form_test.exs
+++ b/test/phoenix_bootstrap_form_test.exs
@@ -231,5 +231,17 @@ defmodule PhoenixBootstrapFormTest do
       ~s(<div class="invalid-feedback">Some error</div>) <>
       ~s(</div></div>)
   end
-
+  
+  test "with dynamic errors", %{form: form} do
+    error = [value: {"Got errors - %{count}", [count: 10]}]
+    form = %Phoenix.HTML.Form{form | errors: error}
+    input = PhoenixBootstrapForm.text_input(form, :value)
+    assert safe_to_string(input) ==
+      ~s(<div class="form-group row">) <>
+      ~s(<label class="col-form-label text-sm-right col-sm-2" for="record_value">Value</label>) <>
+      ~s(<div class="col-sm-10">) <>
+      ~s(<input class="form-control is-invalid" id="record_value" name="record[value]" type="text">) <>
+      ~s(<div class="invalid-feedback">Got errors - 10</div>) <>
+      ~s(</div></div>)
+  end
 end


### PR DESCRIPTION
The problem that this commit solves:
Messages with complex validations were processed, but the get_error method did not return results.

For example:
with line length validation result was
"should be at most% {count} character (s)"

Expected:
"should be at most 255 character (s)"