### PR TITLE
use {Module, Function, Arguments} for custom translate error function

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ function that handles it:
 
 ```elixir
 config :phoenix_bootstrap_form, [
-  translate_error_function: &MyApp.ErrorHelpers.translate_error/1
+  translate_error_function: {MyApp.ErrorHelpers, :translate_error}
 ]
 ```
 

--- a/lib/phoenix_bootstrap_form.ex
+++ b/lib/phoenix_bootstrap_form.ex
@@ -357,16 +357,20 @@ defmodule PhoenixBootstrapForm do
     Tag.content_tag(:div, message, class: "invalid-feedback")
   end
 
+  def default_translate_error({msg, opts}) do
+    Enum.reduce(opts, msg, fn {key, value}, acc ->
+      String.replace(acc, "%{#{key}}", to_string(value))
+    end)
+  end
+
   defp translate_error(msg, opts) do
-    default_fn = fn {msg, opts} ->
-      Enum.reduce(opts, msg, fn {key, value}, acc ->
-        String.replace(acc, "%{#{key}}", to_string(value))
-      end)
-    end
+    {module, function} =
+      Application.get_env(
+        :phoenix_bootstrap_form,
+        :translate_error_function,
+        {__MODULE__, :default_translate_error}
+      )
 
-    translate_error_fn =
-      Application.get_env(:phoenix_bootstrap_form, :translate_error_function, default_fn)
-
-    translate_error_fn.({msg, opts})
+    apply(module, function, [{msg, opts}])
   end
 end

--- a/test/phoenix_bootstrap_form_error_helper_test.exs
+++ b/test/phoenix_bootstrap_form_error_helper_test.exs
@@ -4,12 +4,19 @@ defmodule PhoenixBootstrapFormErrorHelperTest do
 
   doctest PhoenixBootstrapForm
 
+  def custom_translate_error({msg, opts}) do
+    "#{msg}, #{opts[:count]}"
+  end
+
   setup do
-    Application.put_env(:phoenix_bootstrap_form, :translate_error_function, fn {msg, opts} ->
-      "#{msg}, #{opts[:count]}"
-    end)
+    Application.put_env(
+      :phoenix_bootstrap_form,
+      :translate_error_function,
+      {__MODULE__, :custom_translate_error}
+    )
+
     conn = Phoenix.ConnTest.build_conn()
-    form = Phoenix.HTML.FormData.to_form(conn, [as: :record, multipart: true])
+    form = Phoenix.HTML.FormData.to_form(conn, as: :record, multipart: true)
     {:ok, [conn: conn, form: form]}
   end
 
@@ -17,12 +24,13 @@ defmodule PhoenixBootstrapFormErrorHelperTest do
     error = [value: {"Got errors - %{count}", [count: 10]}]
     form = %Phoenix.HTML.Form{form | errors: error}
     input = PhoenixBootstrapForm.text_input(form, :value)
+
     assert safe_to_string(input) ==
-      ~s(<div class="form-group row">) <>
-      ~s(<label class="col-form-label text-sm-right col-sm-2" for="record_value">Value</label>) <>
-      ~s(<div class="col-sm-10">) <>
-      ~s(<input class="form-control is-invalid" id="record_value" name="record[value]" type="text">) <>
-      ~s(<div class="invalid-feedback">Got errors - %{count}, 10</div>) <>
-      ~s(</div></div>)
+             ~s(<div class="form-group row">) <>
+               ~s(<label class="col-form-label text-sm-right col-sm-2" for="record_value">Value</label>) <>
+               ~s(<div class="col-sm-10">) <>
+               ~s(<input class="form-control is-invalid" id="record_value" name="record[value]" type="text">) <>
+               ~s(<div class="invalid-feedback">Got errors - %{count}, 10</div>) <>
+               ~s(</div></div>)
   end
 end


### PR DESCRIPTION
Thanks for this awesome module.

I'm use distillery for releases, but encountered an error while using the custom `translate_error_function` (Same error as in https://github.com/bitwalker/distillery/issues/1859) 

Distillery does not allow function captures in config files.

This PR introduces a breaking change by calling `Kernel.apply/3`

